### PR TITLE
Fix: use country name for region if no region is found in the find_g…

### DIFF
--- a/test.py
+++ b/test.py
@@ -41,6 +41,7 @@ from .test_responses import (
     display_default_response,
     failed_geo_response,
     geo_response,
+    geo_response_without_region,
     weather_response,
 )
 from .utils.errors import LocationNotFound, WeatherNotFound
@@ -193,6 +194,25 @@ class UtilsFindGeoTestCase(SupyTestCase):
         expected = {
             "location": "New York",
             "region": "New York",
+            "coordinates": "40.714,-74.006",
+        }
+        self.assertEqual(service.location, expected["location"])
+        self.assertEqual(service.region, expected["region"])
+        self.assertEqual(service.coordinates, expected["coordinates"])
+
+    def test_find_geolocation_without_region(self, mocker: mock.patch) -> None:
+        """
+        Testing find_geolocation is returning the correct dictionary of results back
+        if no region is found in data, that it will return the country instead.
+        """
+        mocker.return_value.status_code = 200
+        mocker.return_value.json.return_value = geo_response_without_region
+        service = DarkskyAPI("New York, NY")
+        service.find_geolocation()
+
+        expected = {
+            "location": "New York",
+            "region": "USA",
             "coordinates": "40.714,-74.006",
         }
         self.assertEqual(service.location, expected["location"])

--- a/test_responses.py
+++ b/test_responses.py
@@ -12,6 +12,8 @@ geo_response = {
     }
 }
 
+geo_response_without_region = {"location": {**geo_response["location"], "region": "", "country": "USA"}}
+
 failed_geo_response = {
     "success": False,
     "error": {

--- a/utils/weather.py
+++ b/utils/weather.py
@@ -75,8 +75,12 @@ class DarkskyAPI(WeatherAPI):
         lat: str = res_location.get("lat")
         long: str = res_location.get("lon")
 
+        # Sets the location attributes, if region is not found, it will use the country
+        # name. If no country name is found, it will then throw an exception.
         self.location: str = res_location.get("name")
-        self.region: str = res_location.get("region")
+        self.region: str = res_location.get("region") or res_location.get("country")
+        if not self.region:
+            raise LocationNotFound("Unable to find this location.")
         self.coordinates = f"{lat},{long}"
 
     def format_directions(self, degrees: Union[int, None]) -> str:


### PR DESCRIPTION
…eolocation method.

Also if no country is found, it will throw a LocationNotFound exception.

Had an issue with region showing up blank for certain locations with canada postal codes.