### PR TITLE
Fix: Made find_current_weather more efficient by not calling find_geo…

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -60,12 +60,12 @@ class WeatherBot(callbacks.Plugin):
                 irc.reply(f"No weather location set by {msg.nick}", prefixNick=False)
 
             elif not text:
-                weather: str = query_current_weather(f"{user.location}, {user.region}", user.format)
+                weather: str = query_current_weather(text, user)
                 irc.reply(weather, prefixNick=False)
 
             else:
                 deserialized_location: Dict[str, str] = UserSchema().load({"location": html.escape(text)}, partial=True)
-                weather: str = query_current_weather(deserialized_location["location"], user.format)
+                weather: str = query_current_weather(deserialized_location["location"], user)
                 irc.reply(weather, prefixNick=False)
 
         except ValidationError as exc:


### PR DESCRIPTION
…location if there is a User in the database.

The weather command was not completely using the user's coordinates already saved to the db and calling find_geolocation method on every weather command callout no matter what. This fixes the inefficient call and uses the user db settings correctly now.

This also fixes the bug between the setweather command and the weather callout being different than what you set it to.